### PR TITLE
Allow Division order override

### DIFF
--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -67,4 +67,9 @@ class Division < ApplicationRecord
 
     output
   end
+
+  def freeze!
+    self.final_standings = sorted_teams
+    save
+  end
 end

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -2,6 +2,7 @@ class Division < ApplicationRecord
   belongs_to :season
   has_and_belongs_to_many :teams
   has_many :matches
+  serialize :final_standings
 
   def match_time_for_week(week)
     day = season.start_date
@@ -40,6 +41,8 @@ class Division < ApplicationRecord
   end
 
   def sorted_teams
+    return final_standings if final_standings
+
     output = []
 
     # Group and Sort teams by # of wins descending

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -48,15 +48,19 @@ class Division < ApplicationRecord
     # Group and Sort teams by # of wins descending
     # teams_by_win = {2: [], 1: [], 0: []}
     teams_by_win = teams.group_by { |t| t.league_record(self)[:wins] }.sort_by { |k, _v| k }.reverse
-    teams_by_win.each do |_win, win_team_array|
+    teams_by_win.each do |win, win_team_array|
       # Now group and sort the "win" group by # of losses
       teams_by_loss = win_team_array.group_by { |t| t.league_record(self)[:losses] }.sort_by { |k, _v| k }
-      teams_by_loss.each do |_loss, loss_team_array|
+      teams_by_loss.each do |loss, loss_team_array|
         # Now sort within win/loss group by ELO descending
         teams_by_elo = loss_team_array.sort_by(&:elo_cache).reverse
 
         teams_by_elo.each do |t|
-          output.push(t)
+          output.push(
+            team: t,
+            wins: win,
+            losses: loss
+          )
         end
       end
     end

--- a/app/views/divisions/show.html.erb
+++ b/app/views/divisions/show.html.erb
@@ -5,7 +5,7 @@
   <div class="col-lg-6 offset-lg-3">
     <%= render partial: 'layouts/rank_board', locals: {
       title: "#{@division.name} Division",
-      teams: @division.sorted_teams,
+      teams: @teams,
       division: @division
     } %>
   </div>

--- a/app/views/layouts/_rank_board.html.erb
+++ b/app/views/layouts/_rank_board.html.erb
@@ -49,21 +49,21 @@
         <div class="col">
           <div class="dummy-6"></div>
           <div class="in board board-name">
-            <%= t.display_name %>
+            <%= t[:team].display_name %>
           </div>
         </div>
 
         <div class="col-1">
           <div class="dummy"></div>
           <div class="in board board-wins">
-            <%= t.league_record(division)[:wins] %>
+            <%= t[:wins] %>
           </div>
         </div>
 
         <div class="col-1">
           <div class="dummy"></div>
           <div class="in board board-losses">
-            <%= t.league_record(division)[:losses] %>
+            <%= t[:losses] %>
           </div>
         </div>
 
@@ -72,7 +72,7 @@
         <div class="col">
           <div class="dummy-8"></div>
           <div class="in board board-name">
-            <%= t.display_name %>
+            <%= t[:team].display_name %>
           </div>
         </div>
 
@@ -81,16 +81,16 @@
       <div class="col-2">
         <div class="dummy-2"></div>
         <div class="in board board-elo">
-          <%= t.elo_cache %>
+          <%= t[:team].elo_cache %>
         </div>
       </div>
 
       <div class="col-1">
         <div class="dummy"></div>
-        <% if t.elo_cache > t.previous_elo %>
-          <div class="in board board-elo-up">+<%= t.elo_cache - t.previous_elo %></div>
-        <% elsif t.elo_cache < t.previous_elo %>
-          <div class="in board board-elo-down">-<%= t.previous_elo - t.elo_cache %></div>
+        <% if t[:team].elo_cache > t[:team].previous_elo %>
+          <div class="in board board-elo-up">+<%= t[:team].elo_cache - t[:team].previous_elo %></div>
+        <% elsif t[:team].elo_cache < t[:team].previous_elo %>
+          <div class="in board board-elo-down">-<%= t[:team].previous_elo - t[:team].elo_cache %></div>
         <% else %>
           <div class="in board board-elo-same">0</div>
         <% end %>

--- a/db/migrate/20181109052231_add_final_standings_to_division.rb
+++ b/db/migrate/20181109052231_add_final_standings_to_division.rb
@@ -1,0 +1,5 @@
+class AddFinalStandingsToDivision < ActiveRecord::Migration[5.2]
+  def change
+    add_column :divisions, :final_standings, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_215021) do
+ActiveRecord::Schema.define(version: 2018_11_09_052231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2018_10_25_215021) do
     t.integer "day_of_week"
     t.string "time"
     t.bigint "season_id"
+    t.text "final_standings"
     t.index ["season_id"], name: "index_divisions_on_season_id"
   end
 


### PR DESCRIPTION
We break ties by ELO, but the league breaks ties with week 9. This will allow a manual override of the Division's standings.